### PR TITLE
Add note to README.md warning that new Python 3 versions may not be supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ You'll need Python 3, pip, and virtualenv installed first. Note: Your
 Python 3 should installation must have the header files-i.e. install
 ```python3-dev``` or similar package on Linux systems. 
 
+Note that new versions of Python 3 may not be supported due to the version
+of Django used (1.7.5). Python 3.3 has been confirmed to run this successfully.
+
     virtualenv -p python3 env
     source env/bin/activate
     pip install -r requirements_dev.txt


### PR DESCRIPTION
Due to the old version of Django used (1.7.5), some new Python 3 versions seem to be unsupported. It would probably be good to upgrade the Django version (I've looked into doing so, and it seems it would require just a few syntax changes), but in the meantime this clarifies the setup instructions.